### PR TITLE
setup.py: switch from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import setup
+from setuptools import setup
 
 PACKAGE_NAME = "mw2slob"
 


### PR DESCRIPTION
Fixes the following warnings:

/home/buildroot/buildroot/output/build/python-mwscrape2slob-0358818432fc1404ce2ef7d35da7a59d970b77ef/setup.py:2:
 DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
 Use setuptools or check PEP 632 for potential alternatives
  from distutils.core import setup
/home/buildroot/buildroot/output/host/x86_64-buildroot-linux-uclibc/sysroot/usr/lib/python3.10/distutils/dist.py:274:
 UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
/home/buildroot/buildroot/output/host/x86_64-buildroot-linux-uclibc/sysroot/usr/lib/python3.10/distutils/dist.py:274:
 UserWarning: Unknown distribution option: 'zip_safe'
  warnings.warn(msg)
/home/buildroot/buildroot/output/host/x86_64-buildroot-linux-uclibc/sysroot/usr/lib/python3.10/distutils/dist.py:274:
 UserWarning: Unknown distribution option: 'entry_points'
  warnings.warn(msg)

Without this patch /usr/bin/mw2slob is not created.